### PR TITLE
[FIX] date instead of datetime for currency rate

### DIFF
--- a/account_nbu_rates/data/ir_cron.xml
+++ b/account_nbu_rates/data/ir_cron.xml
@@ -3,8 +3,8 @@
     <data>
         <record model="ir.cron" id="update_nbu_rates">
             <field name="name">Update NBU exchange rates</field>
-            <field name="interval_number">1</field>
-            <field name="interval_type">days</field>
+            <field name="interval_number">3</field>
+            <field name="interval_type">hours</field>
             <field name="numbercall">-1</field>
             <field name="doall" eval="False"/>
             <field name="model" eval="'res.currency'"/>

--- a/account_nbu_rates/models/res_currency.py
+++ b/account_nbu_rates/models/res_currency.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
 
-from openerp import models, fields, api, _
-from openerp.exceptions import UserError
-import requests
-import json
-
 import logging
+
+import requests
+
+from openerp import api, fields, models
 _logger = logging.getLogger(__name__)
 
 
@@ -43,10 +42,9 @@ class Currency(models.Model):
 
     @api.model
     def _update_nbu_rates(self):
-        date = self._context.get('date') or fields.Datetime.now()
+        date = self._context.get('date') or fields.Date.today()
         companies = self.env['res.company'].search([])
         for company in companies:
-            base_ccy = company.currency_id
             uah_ccy = self.env['res.currency'].search([
                 ('name', '=', 'UAH'),
                 ('active', '=', True)])
@@ -86,7 +84,7 @@ class Currency(models.Model):
                     continue
                 try:
                     response = r.json()
-                except:
+                except (ValueError, UnicodeDecodeError):
                     _logger.warn('JSON parsing error')
                     continue
                 if r.status_code == 200 and len(response) > 0:


### PR DESCRIPTION
We should override default Datetime format (dd:MM:yyyy hh:mm:ss)
used for currency rate by using only dd:MM:yyyy.
This is required because Invoice date field is dd:MM:yyyy only.
So when invoice is validated date filed is used to search for recent
currency rate and by default wrong rate is used (prev day).